### PR TITLE
Minor edits to enable compatibility with recent torch versions

### DIFF
--- a/dpc/main.py
+++ b/dpc/main.py
@@ -211,8 +211,8 @@ def train(data_loader, model, optimizer, epoch):
         # score is a 6d tensor: [B, P, SQ, B2, N, SQ]
         # similarity matrix is computed inside each gpu, thus here B == num_gpu * B2
         score_flattened = score_.view(B*NP*SQ, B2*NS*SQ)
-        target_flattened = target_.view(B*NP*SQ, B2*NS*SQ)
-        target_flattened = target_flattened.argmax(dim=1)
+        target_flattened = target_.view(B*NP*SQ, B2*NS*SQ).to(cuda)
+        target_flattened = target_flattened.to(int).argmax(dim=1)
 
         loss = criterion(score_flattened, target_flattened)
         top1, top3, top5 = calc_topk_accuracy(score_flattened, target_flattened, (1,3,5))
@@ -263,8 +263,8 @@ def validate(data_loader, model, epoch):
 
             # [B, P, SQ, B, N, SQ]
             score_flattened = score_.view(B*NP*SQ, B2*NS*SQ)
-            target_flattened = target_.view(B*NP*SQ, B2*NS*SQ)
-            target_flattened = target_flattened.argmax(dim=1)
+            target_flattened = target_.view(B*NP*SQ, B2*NS*SQ).to(cuda)
+            target_flattened = target_flattened.to(int).argmax(dim=1)
 
             loss = criterion(score_flattened, target_flattened)
             top1, top3, top5 = calc_topk_accuracy(score_flattened, target_flattened, (1,3,5))

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -50,7 +50,7 @@ def calc_topk_accuracy(output, target, topk=(1,)):
 
     res = []
     for k in topk:
-        correct_k = correct[:k].view(-1).float().sum(0)
+        correct_k = correct[:k].contiguous().view(-1).float().sum(0)
         res.append(correct_k.mul_(1 / batch_size))
     return res
 


### PR DESCRIPTION
Fixes #25, enabling torch compatibility (checked up to 18.1).

`dpc/main.py`, lines 215 and 267:
    - `target_flattened` placed on `cuda` when created, to avoid an error when `criterion()` is called.
    - `target_flattened` converted to `int` before `argmax()` to avoid an error with if `target_flattened` is a boolean tensor.

`utils/utils.py`, line 53:
    - In `correct_k = correct[:k].view(-1).float().sum(0)`, a `contiguous()` call is added to avoid an error when `view(-1)` is called.